### PR TITLE
fixed site title and add top icon #34

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "https://toppers.github.io/hakoniwa/"
 languageCode = "ja"
-title = "Top"
+title = "箱庭"
 theme = "kube"
 description = "IoT／自動運転時代の仮想シミュレーション環境"
 Paginate = 4

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
   </div>
   <div class="hide-sm" id="top">
     <div id="top-brand">
-      <a href="/hakoniwa" title="home">{{ .Site.Title }}</a>
+      <a href="/hakoniwa" title="home"><img src={{ "/img/hakoniwa/icon-70x70.png"  | relURL }}></a>
     </div>
     <nav id="top-nav-main">
       <ul>


### PR DESCRIPTION
サイトのタイトルが正しくなかったので修正しました。
またトップへ戻るリンクをアイコンにしてみました。スマホなどの小さい画面の場合はデフォルトの"Home"が表示されます。