### PR TITLE
Add element of  Params.images . #45

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,7 @@ googleAnalytics = "UA-169187702-1"
   RSSLink = "/index.xml"
   author = "TOPPERS Project HAKONIWA WG" # add your company name
   email = "secretariat@toppers.jp"
+  images = ["img/hakoniwa/icon-144x144.png"]
 
 [[menu.main]]
     name = "箱庭とは"


### PR DESCRIPTION
エントリーにアイキャッチの指定がない場合のog:imageタグの追加を行いました。

次のページでエントリーのTwitterCardsなどを確認してください。
Facebookでのデバッグ表示のページ（[シェアデバッガ](https://developers.facebook.com/tools/debug/)）
Twitterでのデバッグ表示のページ（[Card Validator](https://cards-dev.twitter.com/validator)）

