### PR TITLE
Add single.html on docs folder. #55

### DIFF
--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,0 +1,24 @@
+{{ define "title"}} {{ .Title}} {{end}}
+{{ define "header"}} {{ partial "header" .}} {{end}}
+{{ define "main"}}
+  <div id="main">
+    <div id="hero">
+      <h1> {{ .Title}} </h1>
+      <p class="hero-lead">
+           {{ .Params.bref | safeHTML }}.
+      </p>
+
+    </div> 
+    <div id="kube-component" class="content">
+    {{ partial "toc" .}}
+
+    {{ .Content}}
+<!-- Inject script tag in this template  -->
+    {{if .Params.script}}
+     {{ $script := (delimit (slice "scripts" .Params.script) "/")}}
+    {{ partial (string $script) .}}
+    {{end }}
+    </div>
+    </div>
+{{ end }}
+{{ define "footer"}} {{ partial "footer" .}} {{end}}


### PR DESCRIPTION
`layouts/_default/single.html` が適用されないのはなぜだろうと思いましたが、Kubeのデフォルトテーマで
`kube/layouts/docs/single.html`があるためこちらが優先して適用されるためだとわかりました。
デフォルトテーマについては変更しない方針ですので、layoutsフォルダにdocsセクションを追加しました。