### PR TITLE
新規の記事の書き方とOGPのimagesの設定

### DIFF
--- a/README-web.md
+++ b/README-web.md
@@ -18,3 +18,12 @@ or Reviewing the generated content.
 
 [Install Hugo](https://gohugo.io/getting-started/installing/) (v0.72.0 or later)
 
+## Create new article
+
+    $ hugo new hoge.md
+
+### e.g. in `docs` section
+
+    $ hugo new docs/hoge.md
+
+if only text article, you can remove `images` elements at front matter.

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,11 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
+description: ""
 date: {{ .Date }}
 draft: true
+bref: ""
+
+images: [""]
+
 ---
 

--- a/archetypes/docs.md
+++ b/archetypes/docs.md
@@ -6,4 +6,6 @@ weight = 20
 draft = false
 bref = ""
 toc = true
+images = [""]
+
 +++


### PR DESCRIPTION
#58 としてREADME-webに新規記事をほかのコピーでもいいのですが、hugoコマンドを使うことにしたいと思います。
すでに、mdのテンプレートは登録済みなのでこれにimages要素を追加しました。

確認方法としては、手元の環境でog:imageタグがこの要素で設定されたファイルになっていればOPGの設定としてはOKのはずです。