### PR TITLE
プロトタイプのトップページに画像を張り付けるようにしました

### DIFF
--- a/content/prototypes/harmony-robot.md
+++ b/content/prototypes/harmony-robot.md
@@ -6,6 +6,7 @@ draft = false
 weight = 300
 toc = false
 script = 'animation'
+images = ["img/prototypes/modelC.png"]
 +++
 
 クラウドとロボティクスとの連携を目指した箱庭プロトタイプモデルです．

--- a/content/prototypes/multi-robot.md
+++ b/content/prototypes/multi-robot.md
@@ -6,6 +6,7 @@ draft = false
 weight = 200
 toc = false
 script = 'animation'
+images = ["img/prototypes/modelB.png"]
 +++
 
 複数のECUで構成されるシステムや，FPGAやGPUを混載したシステムを対象とした箱庭プロトタイプモデルです．

--- a/content/prototypes/single-robot.md
+++ b/content/prototypes/single-robot.md
@@ -6,6 +6,7 @@ draft = false
 weight = 100
 toc = true
 script = 'animation'
+images = ["img/prototypes/modelAdemo1.gif"]
 +++
 
 単体のSBCで構成される単体ロボットを対象とした箱庭プロトタイプモデルです．[ETロボコン](https://www.etrobo.jp/)を題材としています．  

--- a/layouts/partials/page-summary.html
+++ b/layouts/partials/page-summary.html
@@ -1,0 +1,13 @@
+<li itemscope itemtype="http://schema.org/CreativeWork">
+    <h2 class="title">
+        <a href="{{ .Permalink }}" itemprop="headline">{{ .Title }}</a>
+    </h2>
+    <hr>
+    {{ if .Description }}
+    <p itemprop="about">{{ .Description }}</p>
+    {{ with $.Params.images }}{{ range first 6 . -}}
+    <p><img src="{{ . | absURL }}"></p>
+    {{ end }}
+    {{ end }}
+    {{ end }}
+</li>


### PR DESCRIPTION
プロトタイプのトップページ（https://toppers.github.io/hakoniwa/prototypes/）の各コンテンツにDesctriptionだけでなく、
コンテンツの画像を表示するようにしました。

あわせて、プロトタイプのmdにimagesのフロントマターを追加しています。（これでOPGのテストにも使えます）