### PR TITLE
remove duplicate news.

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -13,8 +13,6 @@ draft = false
   - ベストポスター賞 ゴールド：TOPPERS/Athrillを使用したAUTOSARモデルカー演習の実機レス化（発表者：庭野正義・安井大介）
 - 2020.07.29
   - [ETロボコン向け TOPPERS活用セミナー](/hakoniwa/technical-links/#et%E3%83%AD%E3%83%9C%E3%82%B3%E3%83%B3%E5%90%91%E3%81%91-toppers%E6%B4%BB%E7%94%A8%E3%82%BB%E3%83%9F%E3%83%8A%E3%83%BC)の動画アーカイブを公開しました。
-- 2020.07.29
-  - [ETロボコン向け TOPPERS活用セミナー](/hakoniwa/technical-links/#et%E3%83%AD%E3%83%9C%E3%82%B3%E3%83%B3%E5%90%91%E3%81%91-toppers%E6%B4%BB%E7%94%A8%E3%82%BB%E3%83%9F%E3%83%8A%E3%83%BC)の動画アーカイブを公開しました。
 - 2020.07.18
   - [ETロボコン向け TOPPERS活用セミナー](/hakoniwa/technical-links/#et%E3%83%AD%E3%83%9C%E3%82%B3%E3%83%B3%E5%90%91%E3%81%91-toppers%E6%B4%BB%E7%94%A8%E3%82%BB%E3%83%9F%E3%83%8A%E3%83%BC)の講演資料を公開しました。
 - 2020.06.12


### PR DESCRIPTION
「2020.07.29, ETロボコン向け TOPPERS活用セミナー」のお知らせが重複していたので削除しました。