### PR TITLE
Web fix singlerobo unity v2.1

### DIFF
--- a/content/single-robot-setup-detail/60_unity_install_v2.1.md
+++ b/content/single-robot-setup-detail/60_unity_install_v2.1.md
@@ -87,35 +87,47 @@ Unity のメニューから，「Edit」⇒「Project Settings」を選択しま
 athrillとUnity間での通信方式に設定を行います．  
 設定は`config.json`という設定ファイルを作成し，設定を行います．
 
-#### config.json の設定例
+#### config.json の設定例(通信方式がMMAPの場合)
+
+設定するファイルパスは全て絶対パスで記述します．
+
+```json
+{
+	"AthrillPath":"/mnt/c/project/esm/athrill/bin/linux/athrill2",
+	"TerminalPath":"C:\\Windows\\System32\\wsl.exe",
+	"robots":[
+		{
+			"RobotName":"RoboModel",
+			"WorkspacePathWin":"C:\\project\\esm\\ev3rt-athrill-v850e2m\\sdk\\workspace",
+			"WorkspacePathUnix":"/mnt/c/project/esm/ev3rt-athrill-v850e2m/sdk/workspace",
+			"ApplicationName":"touch_sensor",
+			"BinaryName":"asp"
+		}
+	]
+}
+```
+
+#### config.json の設定例(通信方式がUDPの場合)
 
 設定するファイルパスは全て絶対パスで記述します．
 
 ```json
 {
 	"AthrillPath":"/mnt/c/project/hakoniwa/athrill/bin/linux/athrill2",
-	"TerminalPath":"c:\\Windows\\System32\\wsl.exe",
+	"TerminalPath":"C:\\Windows\\System32\\wsl.exe",
 	"robots":[
 		{
 			"RobotName":"RoboModel",
-			"WorkspacePathWin":"C:\\project\\hakoniwa\\ev3rt-athrill-ARMv7-A\\sdk",
-			"WorkspacePathUnix":"/mnt/c/project/hakoniwa/ev3rt-athrill-ARMv7-A/sdk",
-			"ApplicationName":"line_trace",
+			"WorkspacePathWin":"C:\\project\\hakoniwa\\ev3rt-athrill-v850e2m\\sdk\\workspace",
+			"WorkspacePathUnix":"/mnt/c/project/hakoniwa/ev3rt-athrill-v850e2m/sdk/workspace",
+			"ApplicationName":"touch_sensor",
 			"BinaryName":"asp",
 			"Udp":
 			{
-				"AthrillIpAddr":"192.168.11.48",
+				"AthrillIpAddr":"127.0.0.1",
 				"AthrillPort":54002,
 				"UnityPort":54001
 			}
-		},
-		{
-			"RobotName":"RoboModel_udp",
-			"WorkspacePathWin":"C:\\project\\hakoniwa\\ev3rt-athrill-ARMv7-A\\sdk",
-			"WorkspacePathUnix":"/mnt/c/project/hakoniwa/ev3rt-athrill-ARMv7-A/sdk",
-			"ApplicationName":"line_trace",
-			"BinaryName":"asp_robot",
-			"Udp":null
 		}
 	]
 }
@@ -144,7 +156,7 @@ athrillとUnity間での通信方式に設定を行います．
 - **BinaryName**  
   athrillが実行するバイナリファイルの名前を設定します．特に名前変更などをしていない限り，ファイル名は`asp`となります．
 - **Udp**  
-  UDPとMMAPどちらの通信方式を使用するか設定します．MMAPを使用する場合は，`null`と設定します．
+  UDPとMMAPどちらの通信方式を使用するか設定します．MMAPを使用する場合は，この項目を省略してください．
 - **AthrillIpAddr**  
   athrillを実行する端末のIPアドレスです．athrillを実行する端末とUnityを実行する端末が同じ場合は，`127.0.0.1`と設定していれば問題ありません．
 - **AthrillPort**  

--- a/content/single-robot-usage/01_Usage_v2.1.md
+++ b/content/single-robot-usage/01_Usage_v2.1.md
@@ -10,7 +10,6 @@ draft = false
 v2.1 で，Unityでのシミュレーション実行をビルドしてバイナリ実行できるようになりました．  
 バイナリ実行でシミュレーション実行を行う場合，
 
-- 制御アプリのビルド
 - Unityシミュレーションの実行，  
 - athrillの実行
 
@@ -68,6 +67,39 @@ Platform は[PC,Mac & Linux Standalone]のままとします．
 {{< image src="/img/single-robot/unity_build_import.png" width="400" >}}
 
 フォルダを選択すると，ビルドが実行されます．
+
+------
+ビルドが完了したら，バイナリが出力されたフォルダ(今回の例では`Build`フォルダ)内に  
+先ほど，Unityプロジェクトフォルダ配下に配置した**config.json**をコピーします．
+
+## 制御アプリのビルド
+
+------
+シミュレーションの実行の前に制御アプリのビルドを行います．  
+ビルド手順は，以下の`EV3ロボット制御プログラムのビルド`をご参照ください．
+
+- [V850版]({{< ref "01_Usage_V850_v2.0.md">}})
+- [ARM版]({{< ref "01_Usage_ARM_v2.0.md">}})
+
+
+### memory_mmap.txtの編集(通信方式にMMAPを使用する場合のみ)
+------
+
+制御アプリのビルドが完了したら，Unityバイナリ実行のためにアプリケーションフォルダにある  
+`memory_mmap.txt`を編集します．  
+使用するMMAPファイルのパスを記述するのですが，Unityバイナリを使用する場合には，  
+MMAPファイルのパスを**絶対パス**で記述するように変更します．
+
+**例：アプリケーション名が`line_tarce`の場合のmemory_mmap.txt**
+
+```
+ROM, 0x00000000, 512
+RAM, 0x00200000, 512
+RAM, 0x05FF7000, 10240
+RAM, 0x07FF7000, 10240
+MMAP, 0x40000000, /mnt/c/project/hakoniwa/ev3rt-athrill-v850e2m/sdk/workspace/line_trace/athrill_mmap.bin
+MMAP, 0x40010000, /mnt/c/project/hakoniwa/ev3rt-athrill-v850e2m/sdk/workspace/line_trace/unity_mmap.bin
+```
 
 ## シミュレーションの実行
 


### PR DESCRIPTION
Unityパッケージv2.1の使用手順に，`memory_mmap.txt`に記載のmmapファイルの絶対パスを
記述する旨が不足していたため，追記しました．
また，細かい導入手順の記載を修正しました．