### PR TITLE
Hugoを最新バージョンにアップデートした

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.72.0'
+          hugo-version: 'latest'
 
       - name: Build
         run: hugo --minify

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 public/
+.hugo_build.lock

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+# copy from https://github.com/gitpod-io/template-hugo/
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - name: Install Hugo dependencies
+    before: brew install hugo
+    init: echo "Your version of Hugo is `hugo version`"
+    command: hugo server -D -F --baseUrl $(gp url 1313) --liveReloadPort=443 --appendPort=false --bind=0.0.0.0
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 1313
+    onOpen: open-preview

--- a/README-web.md
+++ b/README-web.md
@@ -16,7 +16,13 @@ or Reviewing the generated content.
 
 ## Requirements
 
-[Install Hugo](https://gohugo.io/getting-started/installing/) (v0.72.0 or later)
+[Install Hugo](https://gohugo.io/getting-started/installing/) (v0.98.0 or later)
+
+## or Open in Gitpod
+
+Click the button below to start "web branch" development environment:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/toppers/hakoniwa/tree/web)
 
 ## Create new article
 


### PR DESCRIPTION
Hugoのバージョンが0.72を使っていたが、ローカルの環境だと取得できなくなったので、
Hugoを最新バージョンで実行するように変更しました。それに併せて使えなくなったHugoの関数の対応のために
テーマをUpstreamに追従するようにしました。
またGitpodで確認ができるようにGitpodで開けるようにyamlファイルとREADME-Webを追記しました。