### PR TITLE
bump ubuntu to `-latest` for deploying GitHub Pages

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
deploy to GitHub Pages がいつまでも開始しない状況になっていた．
https://github.com/toppers/hakoniwa/actions/runs/4721176557/jobs/8374141579
```
Started 13h 1m 3s ago
Requested labels: ubuntu-18.04
Job defined at: toppers/hakoniwa/.github/workflows/gh_pages.yml@refs/heads/web
Waiting for a runner to pick up this job...
```

調べてみたところ `ubuntu-18.04` は Deprecatedとなっていたらしい．ちょっと不安ではあるが `ubuntu-latest` に bump することにした． https://zenn.dev/azu/articles/5ef880c04560cb