### PR TITLE
Update ga4

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -3,24 +3,41 @@ name: github pages
 on:
   push:
     branches:
-      - web
+      - '**'
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: 'latest'
 
       - name: Build
         run: hugo --minify
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: public
+          path: ./public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/web'
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: public
+          path: ./public
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -23,7 +23,7 @@ jobs:
         run: hugo --minify
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: public
           path: ./public
@@ -34,7 +34,7 @@ jobs:
     if: github.ref == 'refs/heads/web'
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: public
           path: ./public

--- a/config.toml
+++ b/config.toml
@@ -4,9 +4,11 @@ title = "箱庭"
 theme = "kube"
 description = "IoT／クラウドロボティクス時代の仮想シミュレーション環境"
 Paginate = 4
-GoogleAnalytics = "G-57DLKTNNK8"
 
 DefaultContentLanguage = "ja"
+
+[Services.GoogleAnalytics]
+  ID = "G-57DLKTNNK8"
 
 [languages]
   [languages.ja]

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,13 +1,13 @@
 {{ if not hugo.IsServer }}
-{{ with .Site.GoogleAnalytics }}
+{{ with .Site.Config.Services.GoogleAnalytics.ID }}
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '{{ .Site.GoogleAnalytics }}');
+  gtag('config', '{{ . }}');
 </script>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
#176 でGA4対応できていたと思っていたのですが、hugoのアップデートも関連して対応ができていなかったので、
もう一度合わせて送ります。
さらに
webブランチへのpush時にbuildステップを動かしていたのですが、他のブランチでもbuildステップを動かすようにbuildとdeployのステップを分離しました。
これで、他のブランチにpushした時はbuildステップが走り、webブランチにpush(つまりマージ)した時に、deployステップを実行するようにしました。