### PR TITLE
fix paginate parameter

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,11 +1,12 @@
 baseURL = "https://toppers.github.io/hakoniwa"
-languageCode = "ja"
+DefaultContentLanguage = "ja"
+languageCode = "ja-jp"
 title = "箱庭"
 theme = "kube"
 description = "IoT／クラウドロボティクス時代の仮想シミュレーション環境"
-Paginate = 4
 
-DefaultContentLanguage = "ja"
+[pagination]
+  pagerSize = 10
 
 [Services.GoogleAnalytics]
   ID = "G-57DLKTNNK8"


### PR DESCRIPTION
次のエラーメッセージが出ていたので修正対応しました。
```
ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.143.0. Use pagination.pagerSize instead.
```