### PR TITLE
Update release information for July 2026

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -26,7 +26,7 @@ In the series titled "[Recommendations for Embedded Development in the Cloud Age
 - 2026.6.18
   - Repository updates and release information
     - [toppers/hakoniwa-drone-core v4.0.0](https://github.com/toppers/hakoniwa-drone-core/releases/tag/v4.0.0) (2026.6.18)
-      - [Release notes](https://github.com/toppers/hakoniwa-drone-core/blob/main/docs/upgrade_v4.0.0.md)
+      - [Release note](https://github.com/toppers/hakoniwa-drone-core/blob/main/docs/upgrade_v4.0.0.md)
 - 2026.6.17
   - Repository updates and release information
     - [toppers/hakoniwa-drone-core v3.8.1](https://github.com/toppers/hakoniwa-drone-core/releases/tag/v3.8.1) (2026.6.17)

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -23,6 +23,21 @@ In the series titled "[Recommendations for Embedded Development in the Cloud Age
 
 ### What's New
 
+- 2026.6.18
+  - Repository updates and release information
+    - [toppers/hakoniwa-drone-core v4.0.0](https://github.com/toppers/hakoniwa-drone-core/releases/tag/v4.0.0) (2026.6.18)
+      - [Release notes](https://github.com/toppers/hakoniwa-drone-core/blob/main/docs/upgrade_v4.0.0.md)
+- 2026.6.17
+  - Repository updates and release information
+    - [toppers/hakoniwa-drone-core v3.8.1](https://github.com/toppers/hakoniwa-drone-core/releases/tag/v3.8.1) (2026.6.17)
+    - [hakoniwalab/hakoniwa-core-pro v1.3.0](https://github.com/hakoniwalab/hakoniwa-core-pro/releases/tag/v1.3.0) (2026.6.17)
+- 2026.5.31
+  - Repository updates and release information
+    - [hakoniwalab/hakoniwa-mujoco-robots v1.3.0](https://github.com/hakoniwalab/hakoniwa-mujoco-robots/releases/tag/v1.3.0) (2026.5.31)
+      - Support for the latest Hakoniwa core features (incompatible change; the core must be reinstalled)
+- 2026.5.30
+  - Repository updates and release information
+    - [hakoniwalab/hakoniwa-core-pro v1.2.1](https://github.com/hakoniwalab/hakoniwa-core-pro/releases/tag/v1.2.1) (2026.5.30)
 - 2026.5.17
   - Repository updates and release information
     - [toppers/hakoniwa-ecu-multiplay v1.3.0](https://github.com/toppers/hakoniwa-ecu-multiplay/releases/tag/v1.3.0) (2026.5.17)

--- a/content/_index.md
+++ b/content/_index.md
@@ -22,6 +22,21 @@ draft = false
 
 ### 更新情報
 
+- 2026.6.18
+  - リポジトリの更新リリース情報
+    - [toppers/hakoniwa-drone-core v4.0.0](https://github.com/toppers/hakoniwa-drone-core/releases/tag/v4.0.0) (2026.6.18)
+      - [リリースノート](https://github.com/toppers/hakoniwa-drone-core/blob/main/docs/upgrade_v4.0.0.md)
+- 2026.6.17
+  - リポジトリの更新リリース情報
+    - [toppers/hakoniwa-drone-core v3.8.1](https://github.com/toppers/hakoniwa-drone-core/releases/tag/v3.8.1) (2026.6.17)
+    - [hakoniwalab/hakoniwa-core-pro v1.3.0](https://github.com/hakoniwalab/hakoniwa-core-pro/releases/tag/v1.3.0) (2026.6.17)
+- 2026.5.31
+  - リポジトリの更新リリース情報
+    - [hakoniwalab/hakoniwa-mujoco-robots v1.3.0](https://github.com/hakoniwalab/hakoniwa-mujoco-robots/releases/tag/v1.3.0) (2026.5.31)
+      - 箱庭コア機能の最新機能対応（非互換になるので、コア機能の再インストールが必要）
+- 2026.5.30
+  - リポジトリの更新リリース情報
+    - [hakoniwalab/hakoniwa-core-pro v1.2.1](https://github.com/hakoniwalab/hakoniwa-core-pro/releases/tag/v1.2.1) (2026.5.30)
 - 2026.5.17
   - リポジトリの更新リリース情報
     - [toppers/hakoniwa-ecu-multiplay v1.3.0](https://github.com/toppers/hakoniwa-ecu-multiplay/releases/tag/v1.3.0) (2026.5.17)


### PR DESCRIPTION
Slack の notification-development チャンネルのリリース通知（2026.5.17 以降）をもとに、更新情報を追加しました。

- 2026.6.18 toppers/hakoniwa-drone-core v4.0.0（リリースノートリンク付き）
- 2026.6.17 toppers/hakoniwa-drone-core v3.8.1 / hakoniwalab/hakoniwa-core-pro v1.3.0
- 2026.5.31 hakoniwalab/hakoniwa-mujoco-robots v1.3.0
- 2026.5.30 hakoniwalab/hakoniwa-core-pro v1.2.1

対象ファイル: `content/_index.md`, `content/_index.en.md`