### PR TITLE
Update topics: Hakoniwa x AI Night (2026-08-13)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -8,16 +8,6 @@ draft = false
 
 ### トピックス・イベント案内
 
-- 2024年12月8日(日)に 現地開催オフラインイベント を開催しました
-  - [箱庭まつり #2 〜 今年の怒涛の成果を見て触れて総まとめ 〜 忘年会もあるよ](https://hakoniwa.connpass.com/event/336520/)
-  - [アーカイブはYoutube](https://youtube.com/playlist?list=PLvZDKbhDfoh0TEnTo9NyI46qmxcIUw_HN&si=8F3T1PPXb5oIaXGE)からご覧いただけます。
-- 2024年08月10日(土)に 現地開催オフラインイベント を開催しました
-  - [箱庭まつり #1 〜ドローン！デジタルツイン！箱庭のセカイを体験しよう〜](https://hakoniwa.connpass.com/event/323118/)
-  - [アーカイブはYoutube](https://youtube.com/playlist?list=PLvZDKbhDfoh1EMBdcNBYH0RV1wSFJycW4&si=twOGQgIgvae_5MpR)からご覧いただけます。
-- 2024年7月11-12日に開催された [EdgeTech+ WEST 2024](https://www.jasa.or.jp/etwest/) のJASA(組込みシステム技術協会)パビリオンにおいてドローンWGの活動で箱庭WGの紹介と活用事例の発表を行いました。
-  - [箱庭ドローンシミュレータの紹介と活用事例 ～リアル空間・バーチャル空間を使ったシミュレータの活用～](https://f2ff.jp/introduction/9242?event_id=etexpo-west-2024)
-  Speaker:森 崇（箱庭ラボ)
-
 [もっと見る](topics)
 
 ### 更新情報

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,6 +8,9 @@ draft = false
 
 ### トピックス・イベント案内
 
+- 2026年8月13日(木)に オンラインイベント を開催します
+  - [箱庭 × AI Night ― AIが箱庭を使い始める夜 ―](https://hakoniwa.connpass.com/event/402284/)
+
 [もっと見る](topics)
 
 ### 更新情報

--- a/content/topics.md
+++ b/content/topics.md
@@ -10,7 +10,7 @@ toc = true
 - 2024年12月8日(日)に 現地開催オフラインイベント を開催しました
   - [箱庭まつり #2 〜 今年の怒涛の成果を見て触れて総まとめ 〜 忘年会もあるよ](https://hakoniwa.connpass.com/event/336520/)
   - [アーカイブはYoutube](https://youtube.com/playlist?list=PLvZDKbhDfoh0TEnTo9NyI46qmxcIUw_HN&si=8F3T1PPXb5oIaXGE)からご覧いただけます。
-- 2024年08月10日(土)に 現地開催オフラインイベント を開催しました
+- 2024年8月10日(土)に 現地開催オフラインイベント を開催しました
   - [箱庭まつり #1 〜ドローン！デジタルツイン！箱庭のセカイを体験しよう〜](https://hakoniwa.connpass.com/event/323118/)
   - [アーカイブはYoutube](https://youtube.com/playlist?list=PLvZDKbhDfoh1EMBdcNBYH0RV1wSFJycW4&si=twOGQgIgvae_5MpR)からご覧いただけます。
 - 2024年7月11-12日に開催された [EdgeTech+ WEST 2024](https://www.jasa.or.jp/etwest/) のJASA(組込みシステム技術協会)パビリオンにおいてドローンWGの活動で箱庭WGの紹介と活用事例の発表を行いました。

--- a/content/topics.md
+++ b/content/topics.md
@@ -7,6 +7,16 @@ toc = true
 +++
 ### 2024年
 
+- 2024年12月8日(日)に 現地開催オフラインイベント を開催しました
+  - [箱庭まつり #2 〜 今年の怒涛の成果を見て触れて総まとめ 〜 忘年会もあるよ](https://hakoniwa.connpass.com/event/336520/)
+  - [アーカイブはYoutube](https://youtube.com/playlist?list=PLvZDKbhDfoh0TEnTo9NyI46qmxcIUw_HN&si=8F3T1PPXb5oIaXGE)からご覧いただけます。
+- 2024年08月10日(土)に 現地開催オフラインイベント を開催しました
+  - [箱庭まつり #1 〜ドローン！デジタルツイン！箱庭のセカイを体験しよう〜](https://hakoniwa.connpass.com/event/323118/)
+  - [アーカイブはYoutube](https://youtube.com/playlist?list=PLvZDKbhDfoh1EMBdcNBYH0RV1wSFJycW4&si=twOGQgIgvae_5MpR)からご覧いただけます。
+- 2024年7月11-12日に開催された [EdgeTech+ WEST 2024](https://www.jasa.or.jp/etwest/) のJASA(組込みシステム技術協会)パビリオンにおいてドローンWGの活動で箱庭WGの紹介と活用事例の発表を行いました。
+  - [箱庭ドローンシミュレータの紹介と活用事例 ～リアル空間・バーチャル空間を使ったシミュレータの活用～](https://f2ff.jp/introduction/9242?event_id=etexpo-west-2024)
+  Speaker:森 崇（箱庭ラボ)
+
 [このページの先頭に戻る](#top)
 
 ### 2023年


### PR DESCRIPTION
## 概要

トップページのトピックス・イベント案内を更新します。

- 2026年8月13日(木)開催のオンラインイベント「箱庭 × AI Night ― AIが箱庭を使い始める夜 ―」を追加
  - https://hakoniwa.connpass.com/event/402284/
- トップページに残っていた2024年の過去イベント(箱庭まつり #2 / #1、EdgeTech+ WEST 2024)を [トピックス・イベント案内ページ](https://toppers.github.io/hakoniwa/topics/) の「2024年」セクションへ移動

## 変更ファイル

- `content/_index.md`
- `content/topics.md`